### PR TITLE
Fix WITH-MAIN-WINDOW ignoring :main-thread karg

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -326,7 +326,7 @@
                                      (before-exec #'identity)
                                      (after-exec #'identity))
   (labels ((main ()
-             (ensure-qapplication :name name :args qapplication-args :main-thread NIL)
+             (ensure-qapplication :name name :args qapplication-args :main-thread main-thread)
              (let ((window (ensure-qobject window)))
                (handler-bind ((error on-error))
                  #+(and swank windows) (fix-slime)


### PR DESCRIPTION
WITH-MAIN-WINDOW accepts a :main-thread keyword argument, but
ENSURE-QAPPLICATION will always be called with NIL.

Bug was introduced with commit 49a61ae1aa, which added the keyword
argument to WITH-MAIN-WINDOW to disable  TMT usage.